### PR TITLE
Improve pcc 1.1.0 release notes

### DIFF
--- a/content/index.html.md.erb
+++ b/content/index.html.md.erb
@@ -129,7 +129,7 @@ However the numerical value for members, shown in the top bar of the tool, is ac
 Version 1.1 of PCC includes the following new features:
 
 - HTTP session caching is supported in PCC.
-- PCC is compatible with PCF v1.11.
+- PCC is compatible with PCF v1.10 and v1.11.
 - PCC signs BOSH deployments with SHA-2 to prevent certificate collisions.
 - Syslog setup supports standard RFC format.
 


### PR DESCRIPTION
Release notes were confusing because "PCC is compatible with v1.11" read as if its _only_ compatible with 1.11