### PR TITLE
Added documentation for gfsh log exporting

### DIFF
--- a/content/developer.html.md.erb
+++ b/content/developer.html.md.erb
@@ -391,7 +391,7 @@ You can get logs and `.gfs` stats files from your PCC service instances using th
 
 1. Use the [Connect with gfsh](#gfsh-connect) procedure to connect to the service instance you want logs from.
 1. Run `export logs`.
-1. There will be a `.zip` file in the same directory you started gfsh in; this will contain a folder for each member of the cluster. The member's folder will contain the associated log files and stats files for that member.
+1. There will be a `.zip` file in the same directory where you started gfsh. This file this will contain a folder for each member of the cluster. The member's folder will contain the associated log files and stats files for that member.
 
 For more information on the gfsh export command, please refer to the [gfsh export documentation](https://gemfire.docs.pivotal.io/geode/tools_modules/gfsh/command-pages/export.html).
 

--- a/content/developer.html.md.erb
+++ b/content/developer.html.md.erb
@@ -385,6 +385,16 @@ Each server and locator in the cluster will output metrics.
 * member.UsedHeapSize: the number of megabytes currently in use for the heap
 * member.UnusedHeapSizePercentage: the percentage of the total heap size that is not currently being used
 
+### <a id="exporting_logs"></a> Exporting gfsh Logs
+
+You can get logs and `.gfs` stats files from your PCC service instances using the `export logs` command in gfsh.
+
+1. Use the [Connect with gfsh](#gfsh-connect) procedure to connect to the service instance you want logs from.
+1. Run `export logs`.
+1. There will be a `.zip` file in the same directory you started gfsh in; this will contain a folder for each member of the cluster. The member's folder will contain the associated log files and stats files for that member.
+
+For more information on the gfsh export command, please refer to the [gfsh export documentation](https://gemfire.docs.pivotal.io/geode/tools_modules/gfsh/command-pages/export.html).
+
 ## <a id="delete"></a> Deleting a Service Instance
 
 You can delete service instances using the cf CLI. Before doing so, you must remove any existing service keys and app bindings.


### PR DESCRIPTION
Hi @cf-meganmoore ,

We're playing a story to document how to get logs and stats files from a PCC service instance via `export logs`. While this is documented in gfsh docs (because it's a feature of gfsh), we want to make it clear to PCC customers that we support this feature.

We are especially uncertain of where this should go in the developer section's table of contents. We picked a spot, but are pretty ambivalent about it.

**Note** this change should actually go on all the branches (1.0, 1.1, master/1.2) because we've always supported this feature, it's just been undocumented.

[#150299739]