### PR TITLE
Update service-key format.

### DIFF
--- a/content/developer.html.md.erb
+++ b/content/developer.html.md.erb
@@ -189,6 +189,7 @@ The `cf service-key` returns output in the following format:
 
 <pre class='terminal'>
 {
+  "distributed_system_id": "0",
   "locators": [
     "10.244.0.66[55221]",
     "10.244.0.4[55221]",
@@ -201,11 +202,17 @@ The `cf service-key` returns output in the following format:
   "users": [
     {
       "password": "developer-password",
-      "username": "developer"
+      "username": "developer-username",
+      "roles": [
+       "developer"
+      ]
     },
     {
       "password": "cluster_operator-password",
-      "username": "cluster_operator"
+      "username": "cluster_operator-username",
+      "roles": [
+       "cluster_operator"
+      ]
     }
   ]
 }


### PR DESCRIPTION
@cf-meganmoore 
We're changing our service-key format because our usernames now have guids in them (i.e. rather than being `cluster_operator`, the new tile will generate something like `cluster_operator-2341A342B` for new service instances). We updated the service-key example in the doc with the new format.

The docs already refer to these as roles, so it reads fine. I didn't see any docs that talk about automation using the service keys, but we do intend for people to use the roles to select which user they want to use in apps and other scripts that use service keys.


[#151847755]
Signed-off-by: Leah Hanson <lhanson@pivotal.io>