### PR TITLE
V1.0 release notes

### DIFF
--- a/content/index.html.md.erb
+++ b/content/index.html.md.erb
@@ -27,7 +27,7 @@ Current PCC details:
 
 - **Version:** v1.0.7
 - **Release Date:** Aug 14, 2017
-- **Software Component Version:** GemFire v9.0.4
+- **Software Component Version:** GemFire v9.1.1
 - **Compatible Ops Manager Version:** v1.9.x and v1.10.x
 - **Compatible Elastic Runtime Version:** v1.9.21+ and v1.10.x
 - **vSphere Support:** Yes
@@ -226,7 +226,7 @@ The workflow for the PCF admin setting up a PCC service plan:
 
 - PCC can be used as a cache. It supports the [look-aside cache pattern](https://content.pivotal.io/blog/an-introduction-to-look-aside-vs-inline-caching-patterns).
 - PCC can be used to store objects in key/value format, where value can be any object.
-- PCC works with gfsh v9.0.0 and later
+- PCC works with gfsh (gfsh version should be same as the gemfire version mentioned in snapshot)
 - Any gfsh command not explained in the PCC documentation is **not supported**.
 - PCC supports basic OQL queries, with no support for joins.
 

--- a/content/release-notes.html.md.erb
+++ b/content/release-notes.html.md.erb
@@ -7,7 +7,10 @@ owner: Cloud Cache Engineers
 
 **Release Date:** November 15, 2017
 
+Features: 
+
 - Stemcell upgraded to 3445
+- GemFire version upgraded to 9.1.1
 
 ## <a id='v1.0.7'></a>v1.0.7
 


### PR DESCRIPTION
Removed gfsh version support line. we are now pointing to snapshot for all gfsh version to install. Updated release notes to ensure new stemcel and gemfire version