### PR TITLE
Add known issue with 1.3.1

### DIFF
--- a/content/release-notes.html.md.erb
+++ b/content/release-notes.html.md.erb
@@ -21,6 +21,10 @@ the premature idle-time expiration for replicate type regions.
 - Eliminated a deadlock situation that occurred when recovering
 all locators, due to the use of `gfsh configure pdx`.
 
+Known issues in this release:
+
+- If you are iterating on the Async Queue, current `cluster_operator` role does not have the capability to delete the queue. This will be fixed in the future patch releases. 
+
 ## <a id='v130'></a>v1.3.0
 
 **Release Date:**  January 31, 2018

--- a/content/release-notes.html.md.erb
+++ b/content/release-notes.html.md.erb
@@ -23,7 +23,7 @@ all locators, due to the use of `gfsh configure pdx`.
 
 Known issues in this release:
 
-- If you are iterating on the Async Queue, current `cluster_operator` role does not have the capability to delete the queue. This will be fixed in the future patch releases. 
+- If you are iterating on the Async Queue, the current `cluster_operator` role does not have the ability to delete the queue. This will be fixed in future patch releases. 
 
 ## <a id='v130'></a>v1.3.0
 


### PR DESCRIPTION
`cluster_operator` role doesnt have the right permission to delete a
async queue. Adding that as a known issue.

[#152729230]