### PR TITLE
Removed beta from Spring Session Support

### DIFF
--- a/content/developer.html.md.erb
+++ b/content/developer.html.md.erb
@@ -82,8 +82,7 @@ To enable session state caching, do one of the following:
 
 ### <a id="ssc-spring-session"></a> Enable Session State Caching Using Spring Session
 
-Session state caching for apps using [Spring Session](http://projects.spring.io/spring-session/) is a beta feature.
-It uses pre-release versions of Spring Session libraries.
+Developers can also use session state caching for apps using [Spring Session](http://projects.spring.io/spring-session/)
 
 To use `spring-session` with PCC, follow the steps below:
 


### PR DESCRIPTION
We no longer have to say on v1.3.x that spring session is beta support.

[#155790081]