### PR TITLE
Added release notes for v1.3.2

### DIFF
--- a/content/release-notes.html.md.erb
+++ b/content/release-notes.html.md.erb
@@ -3,6 +3,18 @@ title: Pivotal Cloud Cache Release Notes
 owner: Cloud Cache Engineers
 ---
 
+## <a id='v132'></a>v1.3.2 **Limited availability**
+
+**Release Date:**  March 21, 2018
+
+**NOTE: This patch only works with PCC v1.3.0**
+
+Features included in this release:
+
+- PCC is now running Pivotal GemFire v9.2.0
+- Supports upgrade from PCC v1.3.0
+
+
 ## <a id='v131'></a>v1.3.1
 
 **Release Date:**  March 5, 2018


### PR DESCRIPTION
Added release notes for v1.3.2. This is a limited availability release, which means we will expose v1.3.2 only to customer on their request. 