### PR TITLE
Updated a broken reference link

### DIFF
--- a/content/developer.html.md.erb
+++ b/content/developer.html.md.erb
@@ -321,7 +321,7 @@ The following region types are recommended for PCC:
 * `PARTITION_HEAP_LRU`
 * `REPLICATE_HEAP_LRU`
 
-To achieve optimal performance, you should understand the type of region that is relevant to your situation. For more information, see the Pivotal GemFire [Region Types](http://gemfire90.docs.pivotal.io/geode/developing/region_options/region_types.html) documentation.
+To achieve optimal performance, you should understand the type of region that is relevant to your situation. For more information, see the Pivotal GemFire [Region Types](http://gemfire90.docs.pivotal.io/90/geode/developing/region_options/region_types.html) documentation.
 
 You can test the newly created region by writing and reading values with gfsh:
 


### PR DESCRIPTION
The reference link for "Region Types" was broken and updated to "http://gemfire90.docs.pivotal.io/90/geode/developing/region_options/region_types.html".